### PR TITLE
OpenRouter entegrasyonu ve manuel ilaç girişi

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,19 @@
 # Docker:      http://backend:8081
 PYTHON_API_URL=http://localhost:8081
 
-# FAL AI key (proxies to OpenRouter → Claude)
-FAL_KEY=your-fal-key-here
+# ── LLM sağlayıcı: OpenRouter ───────────────────────────────
+# Anahtarı https://openrouter.ai/keys adresinden alın.
+OPENROUTER_API_KEY=sk-or-v1-your-openrouter-key-here
+
+# NOT: Mevcut Railway kurulumunda anahtar FAL_KEY değişkeninde tutuluyor.
+# "sk-or-" ile başlayan bir değer FAL_KEY içinde olsa bile OpenRouter olarak
+# kullanılır, bu yüzden Railway'de değişken adını değiştirmeniz gerekmez.
+# FAL_KEY=sk-or-v1-...
+
+# Opsiyonel — varsayılanları değiştirmek isterseniz
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+# LLM_MODEL=anthropic/claude-sonnet-4.6
+
+# OpenRouter panelinde görünen uygulama bilgisi (opsiyonel)
+# APP_PUBLIC_URL=https://your-app.up.railway.app
+# APP_TITLE=NeuroPharm — Drug Interaction Analysis

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Neuropharm: İlaç Etkileşim Analiz Sistemi
 
-Neuropharm, OpenFDA veritabanını ve **Claude Sonnet 4.5** (FAL AI üzerinden) destekli klinik analiz motorunu kullanarak, hasta odaklı ilaç etkileşim analizleri sunan modern bir sağlık teknolojisi çözümüdür.Demo Linki: https://neuropharm.up.railway.app/
+Neuropharm, OpenFDA veritabanını ve **Claude Sonnet** (OpenRouter üzerinden) destekli klinik analiz motorunu kullanarak, hasta odaklı ilaç etkileşim analizleri sunan modern bir sağlık teknolojisi çözümüdür.Demo Linki: https://neuropharm.up.railway.app/
 
 ## Temel Özellikler
 
@@ -9,13 +9,14 @@ Neuropharm, OpenFDA veritabanını ve **Claude Sonnet 4.5** (FAL AI üzerinden) 
 - **Canlı Veri:** İlaç etiketleri, güncel kara kutu uyarıları ve kontrendikasyonlar anlık olarak sorgulanır.
 - **Önbellekleme (Prefetch):** Hasta seçimi ve ilaç ekleme anında FDA verileri arka planda önceden çekilerek analiz süresi kısaltılır.
 
-### 2. Klinik AI Ajanı (Claude Sonnet 4.5)
-- **Model:** FAL AI OpenRouter proxy üzerinden **Anthropic Claude Sonnet 4.5** modeli kullanılır.
+### 2. Klinik AI Ajanı (Claude Sonnet)
+- **Model:** **OpenRouter** üzerinden **Anthropic Claude Sonnet** modeli kullanılır (`LLM_MODEL` ile değiştirilebilir).
 - **Rolü:** OpenFDA'dan çekilen ham klinik veriyi, bir klinik eczacı bakış açısıyla analiz eder, özetler ve Türkçeleştirir.
 - **Yeteneği:** Sadece veri listelemez; hastanın yaşına, cinsiyetine ve hastalıklarına göre risk değerlendirmesi yapar.
 
 ### 3. Hasta Odaklı Analiz (Doktor Reçete Paneli)
 - **Hasta Yönetimi:** Hasta ekleme, düzenleme ve seçme işlemleri.
+- **Manuel İlaç Girişi:** Doktor, sistemde kayıtlı olmayan ilaçları (yerel marka, majistral, yurt dışı ilaçlar) ad, doz, kullanım sıklığı ve serbest metin notuyla elle reçeteye ekleyebilir. Bu ilaçlar OpenFDA'da bulunamasa bile AI değerlendirmesine dâhil edilir.
 - **Reçete Kaydetme:** Analiz sonrası ilaçlar hastanın profiline kaydedilebilir.
 - **İlaç Alternatifleri:** AI, riskli ilaçlara güvenli alternatif önerir ve tek tıkla değiştirme imkânı sunar.
 - **Özel Popülasyon Analizi:** Geriatrik (65+), Pediatrik ve Hamilelik durumlarına özel risk taraması.
@@ -49,7 +50,7 @@ Sistem, tek bir Docker container içinde çalışan **hibrit** bir mimariye sahi
                     ┌──────────────┘ └──────────────┐
                     ▼                               ▼
            ┌────────────────┐            ┌─────────────────┐
-           │ OpenFDA API    │            │ FAL AI Proxy    │
+           │ OpenFDA API    │            │ OpenRouter      │
            │ api.fda.gov    │            │ Claude Sonnet   │
            └────────────────┘            └─────────────────┘
 ```
@@ -59,7 +60,7 @@ Sistem, tek bir Docker container içinde çalışan **hibrit** bir mimariye sahi
 1. **Prefetch:** Hasta seçimi/ilaç ekleme anında OpenFDA'dan veri arka planda çekilip önbelleğe alınır.
 2. **Analiz İsteği:** Frontend, Next.js API route üzerinden FastAPI backend'e POST isteği gönderir.
 3. **Veri Toplama:** Backend, ilaç isimlerini OpenFDA API'de arar; etiket bilgilerini (uyarılar, etkileşimler, dozaj) çeker.
-4. **AI Analizi:** Ham veri, özel sistem promptu ile Claude Sonnet 4.5 modeline gönderilir.
+4. **AI Analizi:** Ham veri, özel sistem promptu ile OpenRouter üzerinden Claude Sonnet modeline gönderilir.
 5. **Sonuç:** AI, klinik değerlendirmeyi yapılandırılmış Türkçe JSON formatında döner.
 
 ---
@@ -70,7 +71,7 @@ Proje Docker ile tek komutla ayağa kaldırılabilir.
 
 ### Gereksinimler
 - Docker & Docker Compose
-- FAL AI API Anahtarı ([fal.ai](https://fal.ai) üzerinden)
+- OpenRouter API Anahtarı ([openrouter.ai/keys](https://openrouter.ai/keys) üzerinden)
 
 ### Hızlı Başlangıç
 
@@ -83,7 +84,7 @@ Proje Docker ile tek komutla ayağa kaldırılabilir.
 2. **Ortam Değişkenlerini Ayarlayın**
    Proje kökünde `.env` dosyası oluşturun:
    ```bash
-   FAL_KEY=your_fal_api_key_here
+   OPENROUTER_API_KEY=sk-or-v1-your-openrouter-key-here
    ```
 
 3. **Uygulamayı Başlatın**
@@ -112,10 +113,23 @@ Manuel hasta bilgisi ile ilaç etkileşim analizi.
     {"id": "1", "name": "Lisinopril", "dosage": "10mg"}
   ],
   "newMedications": [
-    {"id": "2", "name": "Ibuprofen", "dosage": "400mg"}
+    {"id": "2", "name": "Ibuprofen", "dosage": "400mg"},
+    {
+      "id": "manual-1712345678",
+      "name": "Talcid",
+      "dosage": "500mg",
+      "frequency": "Günde 2 kez",
+      "notes": "Gastrik şikâyet için, 2 hafta",
+      "isManual": true
+    }
   ]
 }
 ```
+
+> `isManual: true` olan ilaçlar doktor tarafından elle yazılmıştır ve OpenFDA'da
+> kaydı olmayabilir; bu ilaçlar `doctor_manual_entries` olarak modele ayrıca
+> iletilir ve farmakolojik bilgi üzerinden değerlendirilir. `notes` alanı klinik
+> bağlam olarak analize dâhil edilir.
 
 **Yanıt:**
 ```json
@@ -191,11 +205,11 @@ druginteraction/
 │   │   ├── prefetch.py     # /prefetch
 │   │   └── health.py       # /health
 │   ├── services/           # İş mantığı katmanı
-│   │   ├── llm.py          # Claude Sonnet 4.5 entegrasyonu
+│   │   ├── llm.py          # Claude Sonnet entegrasyonu (OpenRouter)
 │   │   ├── openfda.py      # OpenFDA API istemcisi
 │   │   ├── anamnesis.py    # Belge okuma ve hasta bilgisi çıkarımı
 │   │   └── chat.py         # Sohbet servisi
-│   ├── config.py           # FAL AI istemci yapılandırması
+│   ├── config.py           # OpenRouter istemci yapılandırması
 │   ├── models.py           # Pydantic modelleri
 │   └── logger.py           # İstek loglama sistemi
 ├── components/             # React bileşenleri
@@ -221,7 +235,7 @@ druginteraction/
 |---|---|
 | Frontend | Next.js 16, React 19, Tailwind CSS 4, TypeScript |
 | Backend | Python 3.13, FastAPI, Uvicorn |
-| AI Model | Anthropic Claude Sonnet 4.5 (FAL AI proxy) |
+| AI Model | Anthropic Claude Sonnet (OpenRouter) |
 | Veri Kaynağı | OpenFDA API (api.fda.gov) |
 | Containerization | Docker (çok aşamalı build) |
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,6 +1,13 @@
 """
 Configuration and client initialization.
 Loads environment variables and creates the LLM client.
+
+LLM provider resolution:
+  1. OPENROUTER_API_KEY        → OpenRouter (https://openrouter.ai/api/v1)
+  2. FAL_KEY holding sk-or-... → OpenRouter too (deployments that reused the old
+                                 variable name for their OpenRouter key)
+  3. FAL_KEY holding a FAL key → FAL AI proxy (legacy)
+  4. neither                   → client is created but unconfigured; calls fail gracefully
 """
 
 import os
@@ -9,29 +16,93 @@ from openai import OpenAI
 
 
 def load_env():
-    """Load .env file from project root."""
+    """Load the project-root .env file without overriding real environment variables."""
     env_path = Path(__file__).parent.parent / ".env"
-    if env_path.exists():
-        with open(env_path) as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith("#") and "=" in line:
-                    key, value = line.split("=", 1)
-                    os.environ[key] = value
+    if not env_path.exists():
+        return
+
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            # Platform env vars (Railway, Docker, CI) win over the .env file
+            os.environ.setdefault(key, value)
 
 
 load_env()
 
-# API Keys & URLs
-FAL_KEY = os.getenv("FAL_KEY")
-OPENFDA_BASE_URL = "https://api.fda.gov/drug/label.json"
-LLM_MODEL = "anthropic/claude-sonnet-4.6"
+# ──────────────────── API keys & URLs ────────────────────
 
-# FAL AI client (OpenRouter proxy, OpenAI-compatible)
-llm_client = OpenAI(
-    base_url="https://fal.run/openrouter/router/openai/v1",
-    api_key="not-needed",
-    default_headers={
-        "Authorization": f"Key {FAL_KEY}",
-    },
-)
+OPENFDA_BASE_URL = "https://api.fda.gov/drug/label.json"
+
+OPENROUTER_API_KEY = (os.getenv("OPENROUTER_API_KEY") or "").strip() or None
+OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+
+# Legacy FAL AI proxy variable. Some deployments keep their OpenRouter key here —
+# a value starting with "sk-or-" is therefore treated as an OpenRouter key.
+FAL_KEY = (os.getenv("FAL_KEY") or "").strip() or None
+
+# OpenRouter API keys always carry this prefix
+_OPENROUTER_KEY_PREFIX = "sk-or-"
+
+# OpenRouter model slug (see https://openrouter.ai/models)
+LLM_MODEL = os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4.6")
+
+# OpenRouter attribution headers (optional, shown on openrouter.ai dashboards)
+APP_PUBLIC_URL = os.getenv("APP_PUBLIC_URL", "https://github.com/Neuronauts-AI/NeuroPharm")
+APP_TITLE = os.getenv("APP_TITLE", "NeuroPharm — Drug Interaction Analysis")
+
+
+# ──────────────────── LLM client ────────────────────
+
+
+def _openrouter_key() -> str | None:
+    """Return the OpenRouter key from either supported variable."""
+    if OPENROUTER_API_KEY:
+        return OPENROUTER_API_KEY
+    # FAL_KEY slot reused for an OpenRouter key (existing Railway deployments)
+    if FAL_KEY and FAL_KEY.startswith(_OPENROUTER_KEY_PREFIX):
+        print("ℹ️  FAL_KEY contains an OpenRouter key — using OpenRouter directly.")
+        return FAL_KEY
+    return None
+
+
+def _build_llm_client() -> tuple:
+    """Create the OpenAI-compatible LLM client for the configured provider."""
+    openrouter_key = _openrouter_key()
+
+    if openrouter_key:
+        client = OpenAI(
+            base_url=OPENROUTER_BASE_URL,
+            api_key=openrouter_key,
+            default_headers={
+                "HTTP-Referer": APP_PUBLIC_URL,
+                "X-Title": APP_TITLE,
+            },
+        )
+        return client, "openrouter"
+
+    if FAL_KEY:
+        client = OpenAI(
+            base_url="https://fal.run/openrouter/router/openai/v1",
+            api_key="not-needed",
+            default_headers={
+                "Authorization": f"Key {FAL_KEY}",
+            },
+        )
+        return client, "fal"
+
+    # No key configured — build a placeholder so imports still work.
+    # Requests will fail and each service falls back to its error message.
+    print("⚠️  No OPENROUTER_API_KEY (or FAL_KEY) set — LLM calls will fail.")
+    return OpenAI(base_url=OPENROUTER_BASE_URL, api_key="missing-api-key"), "unconfigured"
+
+
+llm_client, LLM_PROVIDER = _build_llm_client()
+LLM_CONFIGURED = LLM_PROVIDER != "unconfigured"
+
+print(f"🧠 LLM provider: {LLM_PROVIDER} | model: {LLM_MODEL}")

--- a/backend/models.py
+++ b/backend/models.py
@@ -11,6 +11,10 @@ class MedicationItem(BaseModel):
     name: str = Field(..., min_length=1, max_length=200)
     dosage: Optional[str] = Field(None, max_length=200)
     frequency: Optional[str] = Field(None, max_length=200)
+    # Free-text note the doctor typed for a manually entered medication
+    notes: Optional[str] = Field(None, max_length=1000)
+    # True when the drug was typed by hand instead of picked from the catalogue
+    isManual: bool = False
 
 
 class AnalysisRequest(BaseModel):

--- a/backend/routes/analyze.py
+++ b/backend/routes/analyze.py
@@ -40,11 +40,23 @@ async def analyze(request: AnalysisRequest, req: Request):
             gender=request.gender,
             conditions=request.conditions,
             current_medications=[
-                {"name": med.name, "dosage": med.dosage or "N/A"}
+                {
+                    "name": med.name,
+                    "dosage": med.dosage or "N/A",
+                    "frequency": med.frequency or "N/A",
+                    "notes": med.notes,
+                    "is_manual": med.isManual,
+                }
                 for med in request.currentMedications
             ],
             new_medications=[
-                {"name": med.name, "dosage": med.dosage or "N/A"}
+                {
+                    "name": med.name,
+                    "dosage": med.dosage or "N/A",
+                    "frequency": med.frequency or "N/A",
+                    "notes": med.notes,
+                    "is_manual": med.isManual,
+                }
                 for med in request.newMedications
             ],
             track_pipeline=logger.enabled,

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -3,7 +3,12 @@
 import httpx
 from fastapi import APIRouter
 
-from backend.config import FAL_KEY, OPENFDA_BASE_URL
+from backend.config import (
+    LLM_CONFIGURED,
+    LLM_MODEL,
+    LLM_PROVIDER,
+    OPENFDA_BASE_URL,
+)
 from backend.logger import get_logger
 
 router = APIRouter()
@@ -34,8 +39,11 @@ async def health():
         openfda_status = "offline"
 
     return {
-        "status": "healthy" if openfda_status == "healthy" else "degraded",
-        "fal_configured": FAL_KEY is not None,
+        "status": "healthy" if openfda_status == "healthy" and LLM_CONFIGURED else "degraded",
+        "llm_provider": LLM_PROVIDER,
+        "llm_model": LLM_MODEL,
+        "llm_configured": LLM_CONFIGURED,
+        "fal_configured": LLM_CONFIGURED,  # legacy alias for llm_configured
         "openfda_status": openfda_status,
         "data_source": "OpenFDA API",
         "logging_enabled": logger.enabled,

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -21,6 +21,8 @@ ANALYSIS PRINCIPLES:
 2. Clinical Summary: HIGH-LEVEL overview ONLY. No specific dosage numbers or granular side effect lists here.
 3. Dosage Warnings: The ONLY place for dosage adjustments and specific dosage limits.
 4. Patient Safety: The ONLY place for side effects and red flags.
+5. MANUALLY ENTERED DRUGS: The input may contain a "doctor_manual_entries" list. These drugs were typed by hand by the doctor (local brand names, non-US products, compounded preparations) and often have NO OpenFDA record ("found": false). Identify the active ingredient from your own pharmacological knowledge and evaluate them exactly like the others. NEVER skip a drug just because OpenFDA has no data for it - instead, state briefly in clinical_summary that the evaluation for that drug relies on general pharmacological knowledge rather than FDA label data.
+6. DOCTOR NOTES: If a manual entry has "doctor_notes", treat it as clinical context and factor it into the evaluation.
 
 OUTPUT FORMAT - Return this exact JSON structure in Turkish:
 {
@@ -143,6 +145,32 @@ Focus on:
 # ──────────────────── main pipeline ────────────────────
 
 
+def _collect_manual_entries(medications: List[Dict], kind: str) -> List[Dict[str, Any]]:
+    """Pick out hand-typed medications (and any doctor notes) for the LLM payload."""
+    entries: List[Dict[str, Any]] = []
+
+    for med in medications:
+        name = (med.get("name") or "").strip()
+        if not name:
+            continue
+
+        is_manual = bool(med.get("is_manual") or med.get("isManual"))
+        notes = (med.get("notes") or "").strip()
+        if not is_manual and not notes:
+            continue
+
+        entries.append({
+            "name": name,
+            "type": kind,
+            "dosage": med.get("dosage") or "N/A",
+            "frequency": med.get("frequency") or "N/A",
+            "doctor_notes": notes or None,
+            "manually_entered": is_manual,
+        })
+
+    return entries
+
+
 def _extract_latest_date(openfda_data: Dict[str, Any]) -> str:
     """Extract the latest update date from OpenFDA data."""
     latest_date = "01.01.2024"  # default
@@ -220,6 +248,16 @@ def analyze_with_openai_agent(
 
     step1_ms = (time.time() - t0) * 1000
 
+    # Hand-typed drugs usually have no OpenFDA record — surface them explicitly
+    # so the LLM evaluates them from pharmacological knowledge instead of skipping them.
+    manual_entries = (
+        _collect_manual_entries(current_medications, "current")
+        + _collect_manual_entries(new_medications, "new")
+    )
+    if manual_entries:
+        openfda_data["doctor_manual_entries"] = manual_entries
+        print(f"✍️  {len(manual_entries)} manually entered medication(s) included in the analysis")
+
     if track_pipeline:
         pipeline_steps.append({
             "step": 1,
@@ -246,6 +284,7 @@ def analyze_with_openai_agent(
             "patient_info": openfda_data.get("patient_info", {}),
             "current_medications": openfda_data.get("current_medications", []),
             "new_medications": openfda_data.get("new_medications", []),
+            "doctor_manual_entries": openfda_data.get("doctor_manual_entries", []),
             "openfda_data_summary": {
                 "total_drugs": len(openfda_data.get("openfda_data", [])),
                 "drugs": [

--- a/components/MedicineSearch.tsx
+++ b/components/MedicineSearch.tsx
@@ -10,6 +10,8 @@ interface MedicineSearchProps {
   onRemoveMedicine: (medicineId: string) => void;
 }
 
+const EMPTY_MANUAL_FORM = { name: '', dosage: '', frequency: '', notes: '' };
+
 export default function MedicineSearch({
   availableMedicines,
   selectedMedicines,
@@ -18,11 +20,20 @@ export default function MedicineSearch({
 }: MedicineSearchProps) {
   const [searchTerm, setSearchTerm] = useState('');
   const [showResults, setShowResults] = useState(false);
+  const [showManualForm, setShowManualForm] = useState(false);
+  const [manualForm, setManualForm] = useState(EMPTY_MANUAL_FORM);
+  const [manualError, setManualError] = useState('');
+
+  const isAlreadySelected = (name: string) =>
+    selectedMedicines.some(
+      (selected) => selected.name.trim().toLowerCase() === name.trim().toLowerCase()
+    );
 
   const filteredMedicines = availableMedicines.filter(
     (medicine) =>
       medicine.name.toLowerCase().includes(searchTerm.toLowerCase()) &&
-      !selectedMedicines.some((selected) => selected.id === medicine.id)
+      !selectedMedicines.some((selected) => selected.id === medicine.id) &&
+      !isAlreadySelected(medicine.name)
   );
 
   const handleSelectMedicine = (medicine: Medicine) => {
@@ -30,6 +41,49 @@ export default function MedicineSearch({
     setSearchTerm('');
     setShowResults(false);
   };
+
+  const openManualForm = (prefillName = '') => {
+    setManualForm({ ...EMPTY_MANUAL_FORM, name: prefillName });
+    setManualError('');
+    setShowManualForm(true);
+    setShowResults(false);
+  };
+
+  const closeManualForm = () => {
+    setShowManualForm(false);
+    setManualForm(EMPTY_MANUAL_FORM);
+    setManualError('');
+  };
+
+  const handleAddManualMedicine = () => {
+    const name = manualForm.name.trim();
+
+    if (!name) {
+      setManualError('İlaç adı zorunludur.');
+      return;
+    }
+
+    if (isAlreadySelected(name)) {
+      setManualError('Bu ilaç zaten listede.');
+      return;
+    }
+
+    const manualMedicine: Medicine = {
+      id: `manual-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      name,
+      dosage: manualForm.dosage.trim() || undefined,
+      frequency: manualForm.frequency.trim() || undefined,
+      notes: manualForm.notes.trim() || undefined,
+      isManual: true,
+    };
+
+    onAddMedicine(manualMedicine);
+    setSearchTerm('');
+    closeManualForm();
+  };
+
+  const inputClass =
+    'w-full px-4 py-3 border border-[var(--input-border)] rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 bg-[var(--input-bg)] text-[var(--foreground)]';
 
   return (
     <div className="bg-[var(--card-bg)] rounded-lg shadow-sm border border-[var(--card-border)] p-6 mt-6">
@@ -49,7 +103,7 @@ export default function MedicineSearch({
             }}
             onFocus={() => setShowResults(true)}
             placeholder="İlaç adı yazın..."
-            className="w-full px-4 py-3 border border-[var(--input-border)] rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 bg-[var(--input-bg)] text-[var(--foreground)]"
+            className={inputClass}
           />
 
           {showResults && searchTerm && filteredMedicines.length > 0 && (
@@ -66,15 +120,121 @@ export default function MedicineSearch({
                   </p>
                 </button>
               ))}
+              <button
+                onClick={() => openManualForm(searchTerm)}
+                className="w-full text-left px-4 py-3 border-t border-[var(--card-border)] hover:bg-[var(--hover-bg)] transition-colors text-sm font-medium text-blue-600 dark:text-blue-400"
+              >
+                + Aradığınız ilaç yok mu? &quot;{searchTerm}&quot; ilacını elle ekleyin
+              </button>
             </div>
           )}
 
           {showResults && searchTerm && filteredMedicines.length === 0 && (
-            <div className="absolute z-10 w-full mt-1 bg-[var(--card-bg)] border border-[var(--card-border)] rounded-md shadow-lg p-4 text-[var(--text-muted)] text-sm">
-              İlaç bulunamadı
+            <div className="absolute z-10 w-full mt-1 bg-[var(--card-bg)] border border-[var(--card-border)] rounded-md shadow-lg p-4">
+              <p className="text-[var(--text-muted)] text-sm mb-3">
+                &quot;{searchTerm}&quot; sistemde bulunamadı.
+              </p>
+              <button
+                onClick={() => openManualForm(searchTerm)}
+                className="w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 text-sm font-medium transition-colors"
+              >
+                + &quot;{searchTerm}&quot; ilacını elle ekle
+              </button>
             </div>
           )}
         </div>
+
+        {/* Manuel ilaç girişi — sistemde kayıtlı olmayan ilaçlar için */}
+        {!showManualForm ? (
+          <button
+            type="button"
+            onClick={() => openManualForm(searchTerm.trim())}
+            className="w-full border border-dashed border-[var(--card-border)] text-[var(--text-muted)] px-4 py-3 rounded-md hover:border-blue-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors text-sm font-medium"
+          >
+            + Manuel İlaç Ekle (sistemde olmayan ilaç)
+          </button>
+        ) : (
+          <div className="border border-blue-500/40 bg-blue-500/5 rounded-lg p-4 space-y-3">
+            <div className="flex justify-between items-center">
+              <h4 className="font-semibold text-[var(--foreground)]">Manuel İlaç Girişi</h4>
+              <button
+                type="button"
+                onClick={closeManualForm}
+                className="text-[var(--text-muted)] hover:text-red-500 text-xl leading-none px-1"
+                aria-label="Manuel girişi kapat"
+              >
+                ×
+              </button>
+            </div>
+
+            <p className="text-xs text-[var(--text-muted)]">
+              Sistemde kayıtlı olmayan ilaçları (yerel marka, majistral, yurt dışı ilaçlar) buradan
+              yazabilirsiniz. Etkileşim analizi bu ilaçları da kapsar.
+            </p>
+
+            <input
+              type="text"
+              value={manualForm.name}
+              onChange={(e) => {
+                setManualForm({ ...manualForm, name: e.target.value });
+                setManualError('');
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleAddManualMedicine();
+                }
+              }}
+              placeholder="İlaç adı / etken madde (zorunlu)"
+              autoFocus
+              className={inputClass}
+            />
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <input
+                type="text"
+                value={manualForm.dosage}
+                onChange={(e) => setManualForm({ ...manualForm, dosage: e.target.value })}
+                placeholder="Doz (örn: 500mg)"
+                className={inputClass}
+              />
+              <input
+                type="text"
+                value={manualForm.frequency}
+                onChange={(e) => setManualForm({ ...manualForm, frequency: e.target.value })}
+                placeholder="Sıklık (örn: Günde 2 kez)"
+                className={inputClass}
+              />
+            </div>
+
+            <textarea
+              value={manualForm.notes}
+              onChange={(e) => setManualForm({ ...manualForm, notes: e.target.value })}
+              placeholder="Doktor notu (opsiyonel) — kullanım amacı, süre, özel durum..."
+              rows={2}
+              className={`${inputClass} resize-y`}
+            />
+
+            {manualError && <p className="text-sm text-red-500">{manualError}</p>}
+
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={handleAddManualMedicine}
+                className="flex-1 bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 font-medium transition-colors"
+              >
+                Reçeteye Ekle
+              </button>
+              <button
+                type="button"
+                onClick={closeManualForm}
+                className="px-4 py-2 rounded-md border border-[var(--card-border)] text-[var(--text-muted)] hover:bg-[var(--hover-bg)] transition-colors"
+              >
+                Vazgeç
+              </button>
+            </div>
+          </div>
+        )}
 
         {selectedMedicines.length > 0 && (
           <div>
@@ -88,10 +248,23 @@ export default function MedicineSearch({
                   className="bg-green-500/10 border border-green-500/30 rounded-lg p-4 flex justify-between items-center"
                 >
                   <div>
-                    <h4 className="font-semibold text-[var(--foreground)]">{medicine.name}</h4>
+                    <h4 className="font-semibold text-[var(--foreground)] flex items-center gap-2">
+                      {medicine.name}
+                      {medicine.isManual && (
+                        <span className="text-[10px] uppercase tracking-wider font-bold px-2 py-0.5 rounded-full bg-blue-500/15 text-blue-600 dark:text-blue-400 border border-blue-500/30">
+                          Manuel
+                        </span>
+                      )}
+                    </h4>
                     <p className="text-sm text-[var(--text-muted)]">
-                      {medicine.dosage} - {medicine.frequency}
+                      {[medicine.dosage, medicine.frequency].filter(Boolean).join(' - ') ||
+                        'Doz belirtilmedi'}
                     </p>
+                    {medicine.notes && (
+                      <p className="text-sm text-[var(--text-muted)] italic mt-1">
+                        Not: {medicine.notes}
+                      </p>
+                    )}
                   </div>
                   <button
                     onClick={() => onRemoveMedicine(medicine.id)}

--- a/components/PatientForm.tsx
+++ b/components/PatientForm.tsx
@@ -56,10 +56,11 @@ export default function PatientForm({ patient, onSave, onCancel }: PatientFormPr
         currentMedications: [
           ...formData.currentMedications,
           {
-            id: Date.now().toString(),
+            id: `manual-${Date.now()}`,
             name: medicationInput.name.trim(),
             dosage: medicationInput.dosage.trim(),
             frequency: medicationInput.frequency.trim(),
+            isManual: true,
           },
         ],
       });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,10 @@ services:
       - "3000:3000"
       - "8081:8081"
     environment:
-      - FAL_KEY=${FAL_KEY}
+      # OpenRouter anahtarı (FAL_KEY de desteklenir — geriye dönük uyumluluk)
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - FAL_KEY=${FAL_KEY:-}
+      - LLM_MODEL=${LLM_MODEL:-anthropic/claude-sonnet-4.6}
     volumes:
       - ./backend_logs:/app/backend_logs
     restart: unless-stopped

--- a/types/index.ts
+++ b/types/index.ts
@@ -13,6 +13,10 @@ export interface Medicine {
   name: string;
   dosage?: string;
   frequency?: string;
+  /** Doktorun elle girdiği ilaçlar için serbest metin not */
+  notes?: string;
+  /** true ise ilaç sistemde kayıtlı listeden değil, elle yazılarak eklendi */
+  isManual?: boolean;
 }
 
 export interface Prescription {


### PR DESCRIPTION
LLM sağlayıcısı FAL AI proxy yerine doğrudan OpenRouter:
- backend/config.py, sağlayıcıyı OPENROUTER_API_KEY üzerinden çözer; anahtar "sk-or-" ile başlıyorsa FAL_KEY değişkeninde dursa bile OpenRouter olarak kullanılır (mevcut Railway kurulumu bozulmaz). FAL anahtarı bulunduğunda eski proxy yolu korunur.
- Model artık LLM_MODEL ile değiştirilebilir; OpenRouter panelinde görünmesi için HTTP-Referer / X-Title başlıkları eklendi.
- .env dosyası artık gerçek ortam değişkenlerini ezmiyor.
- /health uç noktası llm_provider, llm_model ve llm_configured döner.

Doktor artık listede olmayan ilaçları elle yazabiliyor:
- MedicineSearch'e manuel giriş formu (ad, doz, sıklık, doktor notu) eklendi; arama sonuç vermediğinde de doğrudan elle ekleme sunuluyor.
- Aynı isimli ilacın iki kez eklenmesi engellendi, manuel ilaçlar listede "Manuel" rozetiyle ve notuyla gösteriliyor.
- notes/isManual alanları Medicine tipine ve MedicationItem şemasına eklendi; elle girilen ilaçlar analiz isteğinde doctor_manual_entries olarak modele iletiliyor. Sistem promptu, OpenFDA kaydı olmayan bu ilaçları atlamak yerine farmakolojik bilgiyle değerlendirmeye ve doktor notunu dikkate almaya yönlendiriyor.


Claude-Session: https://claude.ai/code/session_01Sw6UKkMRva5NtjXu3uugRA